### PR TITLE
Improve error

### DIFF
--- a/client.go
+++ b/client.go
@@ -176,7 +176,9 @@ func (c *Client) apiGet(out any, path string, params url.Values) error {
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("recived bad status code %q", res.Status)
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(res.Body)
+		return fmt.Errorf("received bad status code: %d, body: %s", res.StatusCode, string(buf.Bytes()))
 	}
 	return json.NewDecoder(res.Body).Decode(out)
 }

--- a/client.go
+++ b/client.go
@@ -177,7 +177,7 @@ func (c *Client) apiGet(out any, path string, params url.Values) error {
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		buf := new(bytes.Buffer)
-		buf.ReadFrom(res.Body)
+		_, _ = buf.ReadFrom(res.Body)
 		return fmt.Errorf("received bad status code: %d, body: %s", res.StatusCode, string(buf.Bytes()))
 	}
 	return json.NewDecoder(res.Body).Decode(out)


### PR DESCRIPTION
As an example, if you ask DailySteps from couple years, you would normally get:
> 2024/12/24 22:56:47 received bad status code: 400

With this change in error handling, you will get
> 2024/12/24 22:56:47 received bad status code: 400, body: {"message":"Invalid Dates, difference in days between StartDate and EndDate cannot be more than 28 days.","error":"BadRequestException"}

... which tells you whole lot more about what went wrong.