### PR TITLE
[client] API returns HTTP 204, if there is nothing to return

### DIFF
--- a/client.go
+++ b/client.go
@@ -175,6 +175,9 @@ func (c *Client) apiGet(out any, path string, params url.Values) error {
 		return err
 	}
 	defer res.Body.Close()
+	if res.StatusCode == http.StatusNoContent {
+		return nil
+	}
 	if res.StatusCode != http.StatusOK {
 		return fmt.Errorf("recived bad status code %q", res.Status)
 	}


### PR DESCRIPTION
If we ask for daily steps from the beginning of 1980, we get HTTP 204 as a response, since Garmin doesn't have any record of those. Whether we consider this to be an error or not is something that can be debated, but I would compare it to a database query that doesn't find any matches and as such it is not a real error.
One alternative would be to create something as `ErrNoContent` for easy comparisons.